### PR TITLE
認証関係の機能強化

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -12,7 +12,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 if not SECRET_KEY:
     raise RuntimeError("SECRET_KEY environment variable must be set")
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+ACCESS_TOKEN_EXPIRE_MINUTES = 120
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -7,7 +7,7 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    username = Column(String(50), unique=True, index=True, nullable=False)
+    username = Column(String(10), unique=True, index=True, nullable=False)
     email = Column(String(255), unique=True, index=True, nullable=False)
     hashed_password = Column(String(255), nullable=False)
     is_active = Column(Boolean, default=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -7,7 +7,7 @@ import jwt
 from jwt.exceptions import PyJWTError
 from app.database import get_db
 from app.core.security import create_access_token, verify_password, ACCESS_TOKEN_EXPIRE_MINUTES, SECRET_KEY, ALGORITHM
-from app.crud.user import get_user_by_username, get_user_by_email
+from app.crud.user import get_user_by_email
 from app.schemas.token import Token
 from app.schemas.user import UserResponse, UserLogin
 
@@ -37,13 +37,13 @@ async def get_current_user(
 
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        username: str = payload.get("sub")
-        if username is None:
+        email: str = payload.get("sub")
+        if email is None:
             raise credentials_exception
     except PyJWTError:
         raise credentials_exception from None
     
-    user = await get_user_by_username(db, username=username)
+    user = await get_user_by_email(db, email=email)
     if user is None:
         raise credentials_exception
     if not user.is_active:
@@ -61,7 +61,7 @@ async def login_for_access_token(response: Response, form_data: UserLogin, db: A
         )
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
-        data={"sub": user.username}, expires_delta=access_token_expires
+        data={"sub": user.email}, expires_delta=access_token_expires
     )
     
     # Set HttpOnly Cookie

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -8,14 +8,14 @@ class UserLogin(BaseModel):
     password: str
 
 class UserBase(BaseModel):
-    username: str = Field(..., min_length=1, max_length=50)
+    username: str = Field(..., min_length=1, max_length=10)
     email: EmailStr
 
 class UserCreate(UserBase):
     password: str = Field(..., min_length=8)
 
 class UserUpdate(BaseModel):
-    username: Optional[str] = Field(None, min_length=1, max_length=50)
+    username: Optional[str] = Field(None, min_length=1, max_length=10)
     email: Optional[EmailStr] = None
 
 class UserResponse(UserBase):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,18 @@ const client = axios.create({
     },
 });
 
-// Interceptor removed as we now use HttpOnly cookies
+// Interceptor to handle 401 Unauthorized errors
+client.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        if (error.response && error.response.status === 401) {
+            // Prevent infinite redirect loop if already on auth page
+            if (window.location.pathname !== "/auth") {
+                window.location.href = "/auth";
+            }
+        }
+        return Promise.reject(error);
+    }
+);
 
 export default client;

--- a/frontend/src/pages/auth/AuthPage.tsx
+++ b/frontend/src/pages/auth/AuthPage.tsx
@@ -81,7 +81,7 @@ export default function AuthPage() {
 
     try {
       await login(loginEmail, loginPassword);
-      navigate("/home");
+      // navigation is handled by useEffect when user state changes
     } catch (error: any) {
       console.error("Login failed:", error);
       setLoginError(getErrorMessage(error, "ログインに失敗しました。"));
@@ -97,7 +97,7 @@ export default function AuthPage() {
 
     try {
       await signup(signupUsername, signupEmail, signupPassword);
-      navigate("/home");
+      // navigation is handled by useEffect when user state changes
     } catch (error: any) {
       console.error("Signup failed:", error);
       setSignupError(getErrorMessage(error, "新規登録に失敗しました。"));

--- a/frontend/src/pages/auth/AuthPage.tsx
+++ b/frontend/src/pages/auth/AuthPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent, type ChangeEvent } from "react";
+import { useState, useEffect, type FormEvent, type ChangeEvent } from "react";
 import { Button } from "@/components/ui/button";
 import bgImage from "@/assets/img/doubleyuttin.png";
 import soundFile from "@/assets/sounds/へへっ_T01.wav";
@@ -21,7 +21,13 @@ import { LogIn, UserPlus } from "lucide-react";
 
 export default function AuthPage() {
   const navigate = useNavigate();
-  const { login, signup } = useAuth();
+  const { login, signup, user, loading } = useAuth();
+
+  useEffect(() => {
+    if (!loading && user) {
+      navigate("/home");
+    }
+  }, [user, loading, navigate]);
 
   // Login form state
   const [loginEmail, setLoginEmail] = useState("");

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -190,6 +190,7 @@ export default function SettingsPage() {
                       value={username}
                       onChange={(e) => setUsername(e.target.value)}
                       placeholder="ユーザーネーム"
+                      maxLength={10}
                       className="bg-gray-700/50 border-orange-500/50 text-white placeholder:text-gray-400"
                     />
                   </div>
@@ -316,16 +317,14 @@ export default function SettingsPage() {
                     aria-label="ゆっちんの音トグル"
                   />
                   <div
-                    className={`w-11 h-6 rounded-full transition-colors ${
-                      yucchinSound
+                    className={`w-11 h-6 rounded-full transition-colors ${yucchinSound
                         ? "bg-gradient-to-r from-yellow-400 to-orange-500"
                         : "bg-gray-600"
-                    }`}
+                      }`}
                   />
                   <div
-                    className={`absolute left-1 top-0.5 w-4 h-4 bg-white rounded-full shadow transform transition-transform ${
-                      yucchinSound ? "translate-x-5" : "translate-x-0"
-                    }`}
+                    className={`absolute left-1 top-0.5 w-4 h-4 bg-white rounded-full shadow transform transition-transform ${yucchinSound ? "translate-x-5" : "translate-x-0"
+                      }`}
                   />
                 </label>
               </div>
@@ -350,16 +349,14 @@ export default function SettingsPage() {
                     aria-label="ゆっちん非表示トグル"
                   />
                   <div
-                    className={`w-11 h-6 rounded-full transition-colors ${
-                      yucchinHidden
+                    className={`w-11 h-6 rounded-full transition-colors ${yucchinHidden
                         ? "bg-gradient-to-r from-yellow-400 to-orange-500"
                         : "bg-gray-600"
-                    }`}
+                      }`}
                   />
                   <div
-                    className={`absolute left-1 top-0.5 w-4 h-4 bg-white rounded-full shadow transform transition-transform ${
-                      yucchinHidden ? "translate-x-5" : "translate-x-0"
-                    }`}
+                    className={`absolute left-1 top-0.5 w-4 h-4 bg-white rounded-full shadow transform transition-transform ${yucchinHidden ? "translate-x-5" : "translate-x-0"
+                      }`}
                   />
                 </label>
               </div>


### PR DESCRIPTION
認証トークンの識別子を「ユーザー名」から「メールアドレス」に変更
認証エラー（401）が発生した際、自動的に認証画面（/auth）へリダイレクト
ユーザー名の最大文字数を「50文字」から**「10文字」**に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 401エラー発生時の自動リダイレクトを追加。
  * ログイン後にユーザー状態に応じて自動でホームへ遷移。

* **改善**
  * アクセストークンの有効期限を120分に延長。
  * 認証フローをメール基準へ切替（ログイン/トークンにメールを使用）。
  * ユーザー名の最大長を10文字に統一し、設定画面で入力制限を追加。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->